### PR TITLE
Fix package attributes

### DIFF
--- a/RoaringBitmap/Properties/AssemblyInfo.cs
+++ b/RoaringBitmap/Properties/AssemblyInfo.cs
@@ -5,13 +5,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyTitle("Roaring Bitmap")]
-[assembly: AssemblyDescription("RoaringBitmap for .NET")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("RoaringBitmap Contributors")]
-[assembly: AssemblyProduct("Roaring Bitmap")]
-[assembly: AssemblyCopyright("Copyright © Roaring Bitmap Contributors 2017")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -23,17 +16,3 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("2ee1be04-a8f5-4358-bf08-e417d3916b49")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-
-[assembly: AssemblyVersion("0.0.9.1")]
-[assembly: AssemblyFileVersion("0.0.9.1")]

--- a/RoaringBitmap/RoaringBitmap.csproj
+++ b/RoaringBitmap/RoaringBitmap.csproj
@@ -2,23 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.1</TargetFramework>
-    <AssemblyName>RoaringBitmap</AssemblyName>
-    <PackageId>RoaringBitmap</PackageId>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PackageProjectUrl>https://github.com/Tornhoof/RoaringBitmap</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Tornhoof/RoaringBitmap/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>RoaringBitmap</PackageTags>
-    <RepositoryType></RepositoryType>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/Tornhoof/RoaringBitmap</RepositoryUrl>
     <Version>0.9.1</Version>
+    <Description>RoaringBitmap for .NET</Description>
+    <Authors>RoaringBitmap Contributors</Authors>
+    <Copyright>Copyright © Roaring Bitmap Contributors 2017</Copyright>
+    <Product>Roaring Bitmap</Product>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As [discussed on Twitter](https://twitter.com/torn_hoof/status/855486743386181632): 

There seems to be a bug in the UI where certain settings aren't persisted in the project file when attributes exist in source form (i.e. as assembly level attributes in the `AssemblyInfo.cs`).

This fixes this by:

* Removing the source level attributes
* Specify them to project settings
* Enable generation of AssemblyInfo.cs

I've also cleaned up you project file by removing properties that are defaulted based to the same value.

Hey @davkean: is that behavior above expected?